### PR TITLE
Feedback 2022 10 31

### DIFF
--- a/docs/SECURITY_BASELINE.md
+++ b/docs/SECURITY_BASELINE.md
@@ -45,7 +45,7 @@ Deviating from this baseline is allowed, if valid arguments can be provided, pro
 
 Transport Layer Security provides assurances about the confidentiality, authentication, and integrity of all communications both inside and outside the network. To protect our users and networked systems, the support and use of encrypted communications using TLS is mandatory for all systems.
 
-Various security issues were detected and documented through the years. It is recommended to run TLSv1.0, 1.1 or 1.2 and fully disable SSLv2 and SSLv3 that have protocol weaknesses. TSL 1.3 can be used [if supported by the targeted platforms](https://caniuse.com/?search=TLS%201.3), and should be preferred if all target platforms [support this version](https://wiki.mozilla.org/Security/Server\_Side\_TLS#Modern\_compatibility).
+Various security issues were detected and documented through the years. It is recommended to run TLS 1.2 or 1.3 and fully disable SSLv2, SSLv3, TLS 1.0 and TLS 1.1 that have protocol weaknesses. TSL 1.3 can be used [if supported by the targeted platforms](https://caniuse.com/?search=TLS%201.3), and should be preferred if all target platforms [support this version](https://wiki.mozilla.org/Security/Server\_Side\_TLS#Modern\_compatibility).
 
 If security measures are properly implemented there is no additional security risk in using v1.2.
 

--- a/docs/SECURITY_BASELINE.md
+++ b/docs/SECURITY_BASELINE.md
@@ -105,7 +105,7 @@ Note that disabling inline JavaScript means that all JavaScript must be loaded f
   `default-src 'none'; img-src 'self'; script-src 'self'; style-src 'self’` \
   and then add in sources as revealed during testing.
 * In lieu of the preferred HTTP header, pages can instead include a tag:\
-  `<meta http-equiv=“Content-Security-Policy” content=“…”>`\
+  `<meta http-equiv="Content-Security-Policy" content="…">`\
   If they do, it should be the first tag that appears inside the `<head>`.
 * Care needs to be taken with data: URIs, as these are unsafe inside `script-src` and `object-src` (or inherited from `default-src`).
 * Similarly, the use of `script-src 'self'` can be unsafe for sites with JSONP endpoints. These sites should use a `script-src` that includes the path to their JavaScript source folder(s).

--- a/docs/SECURITY_BASELINE.md
+++ b/docs/SECURITY_BASELINE.md
@@ -106,7 +106,7 @@ Note that disabling inline JavaScript means that all JavaScript must be loaded f
   and then add in sources as revealed during testing.
 * In lieu of the preferred HTTP header, pages can instead include a tag:\
   `<meta http-equiv=“Content-Security-Policy” content=“…”>`\
-  ``If they do, it should be the first tag that appears inside the `<head>`.
+  If they do, it should be the first tag that appears inside the `<head>`.
 * Care needs to be taken with data: URIs, as these are unsafe inside `script-src` and `object-src` (or inherited from `default-src`).
 * Similarly, the use of `script-src 'self'` can be unsafe for sites with JSONP endpoints. These sites should use a `script-src` that includes the path to their JavaScript source folder(s).
 * Unless sites need the ability to execute plugins such as Flash or Silverlight, they should disable their execution with `object-src 'none'`.


### PR DESCRIPTION
* We should not use TLS 1.0 and TLS 1.1 anymore
* Extra backticks removed, they have no function/meaning I think
* Smart quotes converted to regular quotes so people can copy/paste more easily